### PR TITLE
Fix publishing actions broken by upload-artifact@v4

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.os }}
           path: |
             dist
 
@@ -87,7 +87,8 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
+          merge-multiple: true
           path: dist/
 
       - name: Install dependencies

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,7 +3,6 @@ name: Publish to Test PyPI
 on:
   workflow_dispatch:
   push:
-  pull_request:
     branches: [ master ]
 
 jobs:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             dist
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,7 +1,9 @@
 name: Publish to Test PyPI
 
 on:
+  workflow_dispatch:
   push:
+  pull_request:
     branches: [ master ]
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Publish to PyPI
 
 on:
-
+  workflow_dispatch:
+    branches: [ master ]
   release:
     types: [released]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,12 @@ jobs:
             poetry run pytest
 
       - name: Build
-        run: poetry build
+        run: poetry build -f wheel
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.os }}
           path: |
             dist
 
@@ -98,7 +98,8 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
+          merge-multiple: true
           path: dist/
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             dist
 


### PR DESCRIPTION
`actions/upload-artifact@v4` had a braking change preventing uploading to the same artifact.
Applied suggested migration: https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md